### PR TITLE
Update package.json to reflect v14.0.0 of simple-icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@willingtonortiz/svelte-simple-icons",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@willingtonortiz/svelte-simple-icons",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "devDependencies": {
         "@sveltejs/adapter-auto": "^3.0.0",
@@ -27,7 +27,7 @@
         "prettier-plugin-svelte": "^3.2.6",
         "prettier-plugin-tailwindcss": "^0.6.5",
         "publint": "^0.2.0",
-        "simple-icons": "^13.16.0",
+        "simple-icons": "^14.0.0",
         "svelte": "^5.0.0",
         "svelte-check": "^4.0.0",
         "tailwindcss": "^3.4.9",
@@ -37,7 +37,7 @@
         "vitest": "^2.1.4"
       },
       "peerDependencies": {
-        "simple-icons": "^13.16.0",
+        "simple-icons": "^13.16.0 || ^14.0.0",
         "svelte": "^5.0.0"
       }
     },
@@ -4308,9 +4308,9 @@
       }
     },
     "node_modules/simple-icons": {
-      "version": "13.16.0",
-      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-13.16.0.tgz",
-      "integrity": "sha512-aMg1efZ0IvYPKdvqUW0woVGSJwb199y9z7j1+6D5zPMn95eMQN0xzKAHefsqQW2K/5LwfgtFK3Gxn9n1eafX0A==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-14.0.1.tgz",
+      "integrity": "sha512-Pyd2vedjjYTGZCi8Y4a+BeG6ks2qoEwhtJL7t4l6C5DKFxQXRjpLzg7JLBCC44tsk96bXU1XDVEEp+sz58nYlw==",
       "dev": true,
       "engines": {
         "node": ">=0.12.18"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@willingtonortiz/svelte-simple-icons",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/willingtonortiz/svelte-simple-icons.git"
@@ -51,7 +51,7 @@
     }
   },
   "peerDependencies": {
-    "simple-icons": "^13.16.0 || ^14.0.0",
+    "simple-icons": "^14.0.0",
     "svelte": "^5.0.0"
   },
   "devDependencies": {
@@ -73,7 +73,7 @@
     "prettier-plugin-svelte": "^3.2.6",
     "prettier-plugin-tailwindcss": "^0.6.5",
     "publint": "^0.2.0",
-    "simple-icons": "^13.16.0",
+    "simple-icons": "^14.0.0",
     "svelte": "^5.0.0",
     "svelte-check": "^4.0.0",
     "tailwindcss": "^3.4.9",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     }
   },
   "peerDependencies": {
-    "simple-icons": "^13.16.0",
+    "simple-icons": "^13.16.0 || ^14.0.0",
     "svelte": "^5.0.0"
   },
   "devDependencies": {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,7 +3,7 @@
   import { SIIcon } from "$lib/index.js";
 
   let size = $state(64);
-  let color = $state("#000000");
+  let color = $state("#FF3E00");
 
   const code = $derived(
     `<script lang="ts">


### PR DESCRIPTION
Assuming it's compatible...

'npm install simple-icons @willingtonortiz/svelte-simple-icons' currently doesn't work because simple-icons is now on 14.0.0

Small amendment to account for the new major version.